### PR TITLE
Quick fixes

### DIFF
--- a/source/urxvtconfig.cpp
+++ b/source/urxvtconfig.cpp
@@ -345,7 +345,7 @@ void URXVTConfig::saveToFile(QString target)
         msgBox.setText("Question!");
         msgBox.setIcon(QMessageBox::Question);
         msgBox.setInformativeText("Do you wish to backup your existing configuration?");
-        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
         msgBox.setDefaultButton(QMessageBox::Yes);
         int ret = msgBox.exec();
 
@@ -368,6 +368,11 @@ void URXVTConfig::saveToFile(QString target)
                 msgBox.exec();
                  return;
             }
+        }
+        
+        else if(ret == QMessageBox::Cancel)
+        {
+            return;
         }
     }
 

--- a/source/urxvtconfig.ui
+++ b/source/urxvtconfig.ui
@@ -1240,7 +1240,7 @@
   </action>
   <action name="actionSave_to_Xresources">
    <property name="text">
-    <string>Save to .Xresources (Ctrl + Alt + O)</string>
+    <string>Save to .Xresources (Ctrl + Alt + S)</string>
    </property>
   </action>
   <action name="actionSave_to_custom_file">


### PR DESCRIPTION
In Qt message boxes the escape key (and dismissal) will activate a button. In the case of the "backup" dialog the button pressed was "No", which resulted in destructive changes. The addition of a cancel button provides both a faster way to abort the save and prevents data loss.

That and a typo fix :)